### PR TITLE
PuppetBoard isn't yet compatible with Python 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ MarkupSafe >=0.19
 WTForms >=2.1
 Werkzeug >=0.12.1
 itsdangerous >=0.23
-pypuppetdb >=1.2.0
+pypuppetdb >=1.2.0, < 2.0.0
 requests >=2.13.0
 CommonMark==0.7.2


### PR DESCRIPTION
We need to ensure that we don't use version 2.x of Pypuppetdb unti this module supports Python 3.